### PR TITLE
Fix escaping in event/list.json

### DIFF
--- a/apps/frontend/modules/event/templates/listSuccess.json.php
+++ b/apps/frontend/modules/event/templates/listSuccess.json.php
@@ -3,7 +3,7 @@ $result = array();
 foreach ($events as $event){
   $result[] = array(
     "id" => ($event->getId()),
-    "title" => ($event->getAsso()->getName()." - " .$event->getName()), 
+    "title" => ($event->getAsso()->getName(ESC_XSSSAFE)." - " .$event->getName(ESC_XSSSAFE)), 
     "start" => (strtotime($event->getStartDate())),
     "end" => (strtotime($event->getEndDate())),
     "url" => url_for('event_show',$event),


### PR DESCRIPTION
Les caractères spéciaux peuvent être maintenant utilisés.

Avant correction:
![Probl me Calendrier](https://f.cloud.github.com/assets/29782/241019/75c3e5c6-8975-11e2-82b2-ed4b7a56c375.PNG)
