### PR TITLE
Fix d'une erreur lors de la validation de la signature de la charte

### DIFF
--- a/apps/frontend/modules/asso/actions/actions.class.php
+++ b/apps/frontend/modules/asso/actions/actions.class.php
@@ -116,7 +116,7 @@ class assoActions extends sfActions {
       $this->getUser()->setFlash('error', 'Vous n\'avez pas le droit d\'effectuer cette action.');
       $this->redirect('asso/show?login=' . $asso->getLogin());
     }
-    if(!$request->getParameter('check') == $this->getUser()->getUserName())
+    if($request->getParameter('check') != $this->getUser()->getUserName())
     {
       $this->getUser()->setFlash('error', 'La signature n\'est pas correcte.');
       $this->redirect('asso/charte?login=' . $asso->getLogin());


### PR DESCRIPTION
Lors de la signature de la charte informatique, il était possible de rentrer n'importe quoi lors de la validation.
Ce changement interdit cela et oblige l'utilisateur à mettre son login.
