### PR TITLE
Permissions BDE Admin

### DIFF
--- a/apps/bde/modules/charte_locaux/config/security.yml
+++ b/apps/bde/modules/charte_locaux/config/security.yml
@@ -1,0 +1,3 @@
+all:
+  is_secure: true
+  credentials: chartelocaux_gestion

--- a/apps/bde/modules/infojob/config/security.yml
+++ b/apps/bde/modules/infojob/config/security.yml
@@ -1,0 +1,3 @@
+all:
+  is_secure: true
+  credentials: infojob_admin

--- a/apps/bde/modules/infojob_categorie/config/security.yml
+++ b/apps/bde/modules/infojob_categorie/config/security.yml
@@ -1,0 +1,3 @@
+all:
+  is_secure: true
+  credentials: infojob_admin

--- a/apps/bde/modules/infojob_disponibilite/config/security.yml
+++ b/apps/bde/modules/infojob_disponibilite/config/security.yml
@@ -1,0 +1,3 @@
+all:
+  is_secure: true
+  credentials: infojob_admin

--- a/apps/bde/modules/infojob_offre/config/security.yml
+++ b/apps/bde/modules/infojob_offre/config/security.yml
@@ -1,0 +1,3 @@
+all:
+  is_secure: true
+  credentials: infojob_admin

--- a/apps/bde/modules/infojob_signalement/config/security.yml
+++ b/apps/bde/modules/infojob_signalement/config/security.yml
@@ -1,0 +1,3 @@
+all:
+  is_secure: true
+  credentials: infojob_admin

--- a/apps/bde/modules/service/config/security.yml
+++ b/apps/bde/modules/service/config/security.yml
@@ -1,3 +1,3 @@
 all:
   is_secure: true
-  credentials: services
+  credentials: services_admin

--- a/apps/bde/modules/weekmail/config/security.yml
+++ b/apps/bde/modules/weekmail/config/security.yml
@@ -1,0 +1,3 @@
+all:
+  is_secure: true
+  credentials: weekmail_admin


### PR DESCRIPTION
Ajout de permissions pour la gestion d'infojob, des weekmails, des services et des chartes locaux (pour pouvoir donner les droits au BDE)
