### PR TITLE
Utiliser des URL complètes pour Facebook

### DIFF
--- a/apps/frontend/modules/article/templates/showSuccess.php
+++ b/apps/frontend/modules/article/templates/showSuccess.php
@@ -35,7 +35,7 @@
 
   <p>
     <a href="https://www.facebook.com/sharer/sharer.php?u=<?php
-    echo urlencode(url_for('article_show', $article))
+    echo urlencode(url_for('article_show', $article, true))
     ?>&t=<?php echo urlencode($article->getName()) ?>" target="_blank" class="facebook">
       Partager sur Facebook
     </a>

--- a/apps/frontend/modules/event/templates/showSuccess.php
+++ b/apps/frontend/modules/event/templates/showSuccess.php
@@ -36,7 +36,7 @@
   <p><?php echo nl2br($event->getDescription(ESC_XSSSAFE)) ?></p>
   <p>
     <a href="https://www.facebook.com/sharer/sharer.php?u=<?php
-    echo urlencode(url_for('event_show', $event))
+    echo urlencode(url_for('event_show', $event, true))
     ?>&t=<?php echo urlencode($event->getName()) ?>" target="_blank" class="facebook">
       Partager sur Facebook
     </a>


### PR DESCRIPTION
Il faut passer le http://assos.utc.fr dans l'URL qu'on envoie à Facebook
