### PR TITLE
Correctif locaux bde

### DIFF
--- a/apps/bde/modules/charte_locaux/actions/actions.class.php
+++ b/apps/bde/modules/charte_locaux/actions/actions.class.php
@@ -59,11 +59,11 @@ EOF
 
     if ($charte->getPorteMde()) $acces='Vous avez désormais accès à la "Porte de la MDE"';
     else if ($charte->getBatA()) $acces='Vous avez désormais accès au "Batiment A"';
-         else if ($charte->getLocauxPic()) $acces='Vous avez désormais accès au "locaux du Pic"';
-          else if ($charte->getMdeComplete()) $acces='Vous avez désormais accès à la "Mde Complète"';
-            else if ($charte->getBureauPolar()) $acces='Vous avez désormais accès au "Bureau du Polar"';
-              else if ($charte->getPermPolar()) $acces='Vous avez désormais accès à la "Perm du Polar"';
-                else if ($charte->getSallesMusique()) $acces='Vous avez désormais accès aux "Salles de musique"';
+    else if ($charte->getLocauxPic()) $acces='Vous avez désormais accès au "locaux du Pic"';
+    else if ($charte->getMdeComplete()) $acces='Vous avez désormais accès à la "Mde Complète"';
+    else if ($charte->getBureauPolar()) $acces='Vous avez désormais accès au "Bureau du Polar"';
+    else if ($charte->getPermPolar()) $acces='Vous avez désormais accès à la "Perm du Polar"';
+    else if ($charte->getSallesMusique()) $acces='Vous avez désormais accès aux "Salles de musique"';
 
     $message = $this->getMailer()->compose(
     array('bde@assos.utc.fr' => 'BDE UTC'),

--- a/apps/bde/modules/charte_locaux/actions/actions.class.php
+++ b/apps/bde/modules/charte_locaux/actions/actions.class.php
@@ -58,7 +58,7 @@ EOF
     $charte->setStatut(3);
 
     if ($charte->getPorteMde()) $acces='Vous avez désormais accès à la "Porte de la MDE"';
-    else if ($charte->getPorteMde()) $acces='Vous avez désormais accès au "Batiment A"';
+    else if ($charte->getBatA()) $acces='Vous avez désormais accès au "Batiment A"';
          else if ($charte->getLocauxPic()) $acces='Vous avez désormais accès au "locaux du Pic"';
           else if ($charte->getMdeComplete()) $acces='Vous avez désormais accès à la "Mde Complète"';
             else if ($charte->getBureauPolar()) $acces='Vous avez désormais accès au "Bureau du Polar"';

--- a/apps/bde/modules/charte_locaux/actions/actions.class.php
+++ b/apps/bde/modules/charte_locaux/actions/actions.class.php
@@ -56,7 +56,15 @@ EOF
       $this->redirect('charte_locaux');
     }
     $charte->setStatut(3);
-    
+
+    if ($charte->getPorteMde()) $acces='Vous avez désormais accès à la "Porte de la MDE"';
+    else if ($charte->getPorteMde()) $acces='Vous avez désormais accès au "Batiment A"';
+         else if ($charte->getLocauxPic()) $acces='Vous avez désormais accès au "locaux du Pic"';
+          else if ($charte->getMdeComplete()) $acces='Vous avez désormais accès à la "Mde Complète"';
+            else if ($charte->getBureauPolar()) $acces='Vous avez désormais accès au "Bureau du Polar"';
+              else if ($charte->getPermPolar()) $acces='Vous avez désormais accès à la "Perm du Polar"';
+                else if ($charte->getSallesMusique()) $acces='Vous avez désormais accès aux "Salles de musique"';
+
     $message = $this->getMailer()->compose(
     array('bde@assos.utc.fr' => 'BDE UTC'),
     $charte->getResponsable()->getEmailAddress(),
@@ -65,6 +73,7 @@ EOF
 Bonjour,
 
 Votre demande d'accès étendu du {$charte->getCreatedAt()} pour l'association {$charte->getAsso()->getName()} a été acceptée.
+{$acces}
 
 Le BDE
 EOF

--- a/apps/bde/modules/charte_locaux/lib/charte_locauxGeneratorConfiguration.class.php
+++ b/apps/bde/modules/charte_locaux/lib/charte_locauxGeneratorConfiguration.class.php
@@ -10,4 +10,8 @@
  */
 class charte_locauxGeneratorConfiguration extends BaseCharte_locauxGeneratorConfiguration
 {
+  public function getFilterDefaults()
+  {  
+    return array('statut' => 2); 
+  }
 }


### PR DESCRIPTION
2 correctifs pour le bde admin.
-Le premier rajoute dans l'email l'accès qui a été accepté (je n'ai pas pu tester les motifs car l'envoie du mail crée chez moi une erreur 500 mais ça doit être bon).
-Le second met par défaut le statut 2 au filter pour faciliter l'acceptation des chartes par le resp' locaux.
Sachant que la carte étudiante supporte seulement un accès étendu.
