### PR TITLE
Disable redirect to referer after a successful login

### DIFF
--- a/plugins/sfUTCCASPlugin/modules/utcCas/actions/actions.class.php
+++ b/plugins/sfUTCCASPlugin/modules/utcCas/actions/actions.class.php
@@ -17,7 +17,7 @@ class utcCasActions extends sfActions
     public function executeLogin(sfWebRequest $request)
     {
         $this->getUser()->login();
-        $this->redirect($this->getUser()->getReferer($request->getReferer()) ? $this->getUser()->getReferer($request->getReferer()) : 'homepage');
+        $this->redirect('homepage');
     }
 
     /**


### PR DESCRIPTION
The redirect to the referer don't work on http version. It always redirect to homepage.
On the https version, there are too many redirects between this module and the CAS service
