### PR TITLE
Ajout de certaines dates dans le tableau récap des weekmails.

### DIFF
--- a/apps/bde/modules/weekmail/templates/indexSuccess.php
+++ b/apps/bde/modules/weekmail/templates/indexSuccess.php
@@ -44,49 +44,73 @@
 </table>
 <h1>Events à valider <small>Les événements seront ajoutés au premier Weekmail de la liste précédente</small></h1>
 <table class="table table-striped table-bordered table-hover">
-    <?php foreach ($events as $event): ?>
+    <thead>
         <tr>
-            <td>
-                <?php echo $event->getAsso()->getName() ?>
-            </td>
-            <td>
-                <a href="javascript:;" class="article_name"><?php echo $event->getName() ?></a>
-            </td>
-            <td style="width: 60%;"><?php echo nl2br($event->getSummary()) ?></td>
-            <td style="min-width: 72px;">
-                <div class="btn-group">
-                    <a href="<?php echo url_for('weekmail_accept_event', $event) ?>" class="btn btn-success"><i class="icon-ok icon-white"></i></a>
-                    <a href="<?php echo url_for('weekmail_refuse_event', $event) ?>" class="btn btn-danger"><i class="icon-remove icon-white"></i></a>
-                </div>
-            </td>
+            <th>Asso</th>
+            <th>Nom</th>
+            <th>Débute le</th>
+            <th>Résumé</th>
+            <th>Actions</th>
         </tr>
-        <tr class="article_text">
-            <td colspan="4"><?php echo nl2br($event->getDescription()) ?></td>
-        </tr>
-    <?php endforeach; ?>
+    </thead>
+    <tbody>
+        <?php foreach ($events as $event): ?>
+            <tr>
+                <td>
+                    <?php echo $event->getAsso()->getName() ?>
+                </td>
+                <td>
+                    <a href="javascript:;" class="article_name"><?php echo $event->getName() ?></a>
+                </td>
+                <td><?php echo format_date($event->getStartDate(), 'd MMMM à HH:mm', 'fr'); ?></td>
+                <td style="width: 60%;"><?php echo nl2br($event->getSummary()) ?></td>
+                <td style="min-width: 72px;">
+                    <div class="btn-group">
+                        <a href="<?php echo url_for('weekmail_accept_event', $event) ?>" class="btn btn-success"><i class="icon-ok icon-white"></i></a>
+                        <a href="<?php echo url_for('weekmail_refuse_event', $event) ?>" class="btn btn-danger"><i class="icon-remove icon-white"></i></a>
+                    </div>
+                </td>
+            </tr>
+            <tr class="article_text">
+                <td colspan="4"><?php echo nl2br($event->getDescription()) ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </tbody>
 </table>
 <h1>Articles à valider <small>Les articles seront ajoutés au premier Weekmail de la liste précédente</small></h1>
 <table class="table table-striped table-bordered table-hover">
-    <?php foreach ($articles as $article): ?>
+    <thead>
         <tr>
-            <td>
-                <?php echo $article->getAsso()->getName() ?>
-            </td>
-            <td>
-                <a href="javascript:;" class="article_name"><?php echo $article->getName() ?></a>
-            </td>
-            <td style="width: 60%;"><?php echo nl2br($article->getSummary()) ?></td>
-            <td style="min-width: 72px;">
-                <div class="btn-group">
-                    <a href="<?php echo url_for('weekmail_accept', $article) ?>" class="btn btn-success"><i class="icon-ok icon-white"></i></a>
-                    <a href="<?php echo url_for('weekmail_refuse', $article) ?>" class="btn btn-danger"><i class="icon-remove icon-white"></i></a>
-                </div>
-            </td>
+            <th>Asso</th>
+            <th>Titre</th>
+            <th>Crée le</th>
+            <th>Résumé</th>
+            <th>Actions</th>
         </tr>
-        <tr class="article_text">
-            <td colspan="4"><?php echo nl2br($article->getText()) ?></td>
-        </tr>
-    <?php endforeach; ?>
+    </thead>
+    <tbody>
+        <?php foreach ($articles as $article): ?>
+            <tr>
+                <td>
+                    <?php echo $article->getAsso()->getName() ?>
+                </td>
+                <td>
+                    <a href="javascript:;" class="article_name"><?php echo $article->getName() ?></a>
+                </td>
+                <td><?php echo $article->getCreatedAt() ?></td>
+                <td style="width: 60%;"><?php echo nl2br($article->getSummary()) ?></td>
+                <td style="min-width: 72px;">
+                    <div class="btn-group">
+                        <a href="<?php echo url_for('weekmail_accept', $article) ?>" class="btn btn-success"><i class="icon-ok icon-white"></i></a>
+                        <a href="<?php echo url_for('weekmail_refuse', $article) ?>" class="btn btn-danger"><i class="icon-remove icon-white"></i></a>
+                    </div>
+                </td>
+            </tr>
+            <tr class="article_text">
+                <td colspan="4"><?php echo nl2br($article->getText()) ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </tbody>
 </table>
 <h1>Les derniers weekmails</h1>
 <table class="table table-striped table-bordered table-hover">

--- a/apps/bde/modules/weekmail/templates/indexSuccess.php
+++ b/apps/bde/modules/weekmail/templates/indexSuccess.php
@@ -1,4 +1,7 @@
-<?php use_javascript('bde_weekmail') ?>
+<?php
+use_javascript('bde_weekmail');
+use_helper('Date');
+?>
 <a href="<?php echo url_for('weekmail/new') ?>" class="btn btn-success" style="float: right;"><i class="icon-plus icon-white"></i>&nbsp;&nbsp;Nouveau weekmail</a>
 <h1>Prochain weekmail</h1>
 <table class="table table-striped table-bordered table-hover">
@@ -62,7 +65,7 @@
                 <td>
                     <a href="javascript:;" class="article_name"><?php echo $event->getName() ?></a>
                 </td>
-                <td><?php echo format_date($event->getStartDate(), 'd MMMM à HH:mm', 'fr'); ?></td>
+                <td><?php echo format_date($event->getStartDate(), 'd MMMM y à HH:mm', 'fr'); ?></td>
                 <td style="width: 60%;"><?php echo nl2br($event->getSummary()) ?></td>
                 <td style="min-width: 72px;">
                     <div class="btn-group">
@@ -97,7 +100,7 @@
                 <td>
                     <a href="javascript:;" class="article_name"><?php echo $article->getName() ?></a>
                 </td>
-                <td><?php echo $article->getCreatedAt() ?></td>
+                <td><?php echo format_date($article->getCreatedAt(), 'd MMMM y à HH:mm', 'fr')?></td>
                 <td style="width: 60%;"><?php echo nl2br($article->getSummary()) ?></td>
                 <td style="min-width: 72px;">
                     <div class="btn-group">

--- a/apps/bde/modules/weekmail/templates/indexSuccess.php
+++ b/apps/bde/modules/weekmail/templates/indexSuccess.php
@@ -72,7 +72,7 @@
                 </td>
             </tr>
             <tr class="article_text">
-                <td colspan="4"><?php echo nl2br($event->getDescription()) ?></td>
+                <td colspan="5"><?php echo nl2br($event->getDescription()) ?></td>
             </tr>
         <?php endforeach; ?>
     </tbody>
@@ -107,7 +107,7 @@
                 </td>
             </tr>
             <tr class="article_text">
-                <td colspan="4"><?php echo nl2br($article->getText()) ?></td>
+                <td colspan="5"><?php echo nl2br($article->getText()) ?></td>
             </tr>
         <?php endforeach; ?>
     </tbody>


### PR DESCRIPTION
On ajoute certaines dates pour que Léa ne se perde plus lorsqu'elle valide un article/événement pour un weekmail. (Voir mail du 8 avril).

J'ai pas pu vérifier, je dois vraiment m'installer le portail en local... (désolé Corentin)
